### PR TITLE
Bug fixes

### DIFF
--- a/miner.c
+++ b/miner.c
@@ -10516,7 +10516,7 @@ struct work *get_work(struct thr_info *thr)
 		if (unlikely(work->work_difficulty < min_nonce_diff))
 		{
 			if (min_nonce_diff - work->work_difficulty > 1./0x10000000)
-				applog(LOG_WARNING, "%"PRIpreprv": Using work with lower difficulty than device supports",
+				applog(LOG_DEBUG, "%"PRIpreprv": Using work with lower difficulty than device supports",
 				       cgpu->proc_repr);
 			work->nonce_diff = min_nonce_diff;
 		}

--- a/ocl.c
+++ b/ocl.c
@@ -891,7 +891,7 @@ bool opencl_get_kernel_binary(struct cgpu_info * const cgpu, _clState * const cl
 	applog(LOG_DEBUG, "%s: Binary size found in binary slot %u: %"PRId64, cgpu->dev_repr, (unsigned)slot, (int64_t)binary_sizes[slot]);
 	if (!binary_sizes[slot])
 		applogr(false, LOG_ERR, "OpenCL compiler generated a zero sized binary, FAIL!");
-	status = clGetProgramInfo(kernelinfo->program, CL_PROGRAM_BINARIES, sizeof(binaries), binaries, NULL);
+	status = clGetProgramInfo(kernelinfo->program, CL_PROGRAM_BINARIES, sizeof(uint8_t *) * cpnd, binaries, NULL);
 	if (unlikely(status != CL_SUCCESS))
 		applogr(false, LOG_ERR, "Error %d: Getting program info. CL_PROGRAM_BINARIES (clGetProgramInfo)", status);
 	

--- a/util.c
+++ b/util.c
@@ -2643,6 +2643,12 @@ static bool parse_notify(struct pool *pool, json_t *val)
 	if (!job_id)
 		goto out;
 
+	if (pool->swork.job_id != NULL && !strcmp(job_id, pool->swork.job_id)) {
+		applog(LOG_DEBUG, "Duplicate job_id received %s", job_id);
+		ret = pool->stratum_notify;
+		goto out;
+	}
+
 	cg_wlock(&pool->data_lock);
 	cgtime(&pool->swork.tv_received);
 	free(pool->swork.job_id);


### PR DESCRIPTION
Fixed the following error caused when using more than one GPU. Binary files should be correctly generated for multiple GPUs now.
`Error -30: Getting program info. CL_PROGRAM_BINARIES (clGetProgramInfo)`

Fixed an issue where notify is sent immediately after a difficulty change, causing current work to be reset and duplicate shares submitted.