### PR TITLE
Nvidia busywait fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,9 +13,9 @@ dnl * any later version.  See COPYING for more details.
 
 ##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##
 ##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##
-m4_define([v_maj], [5])
-m4_define([v_min], [5])
-m4_define([v_mic], [0])
+m4_define([v_maj], [1])
+m4_define([v_min], [0])
+m4_define([v_mic], [3])
 ##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##
 m4_define([v_ver], [v_maj.v_min.v_mic])
 m4_define([lt_rev], m4_eval(v_maj + v_min))
@@ -24,7 +24,7 @@ m4_define([lt_age], v_min)
 ##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##
 ##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##--##
 
-AC_INIT([bfgminer], [v_ver], [luke-jr+bfgminer@utopios.org])
+AC_INIT([rad-bfgminer], [v_ver], [])
 
 AC_PREREQ([2.59c])
 AC_CANONICAL_SYSTEM

--- a/gen-version.sh
+++ b/gen-version.sh
@@ -4,7 +4,7 @@ if [ -e .git ]; then
 	# Some versions of git require `git diff` to scan and update dirty-or-not status
 	git diff >/dev/null 2>/dev/null
 	
-	gitdesc=$(git describe)
+	gitdesc=$(git describe 2>/dev/null)
 fi
 if [ -z "$gitdesc" ]; then
 	current=$(sed 's/^\#define[[:space:]]\+BFG_GIT_DESCRIBE[[:space:]]\+\"\(.*\)\"$/\1/;t;d' version.h)

--- a/make-release
+++ b/make-release
@@ -15,7 +15,7 @@ sw="$1"; shift || true
 
 test -n "$DEBUG_RELEASE" || DEBUG_RELEASE=1
 
-builds=(win32 win64)
+builds=(win64)
 
 win32_machine='i686-pc-mingw32'
 win32_CFLAGS='-march=i686'
@@ -41,7 +41,7 @@ sed 's/^\[submodule "\(.*\)"\]$/\1/;t;d' .gitmodules |
 done
 git submodule update --init
 {
-	git archive --prefix "$sw"/ --format tar "$tag"
+	git archive --prefix "$sw"/ --format tar TMP
 	git submodule --quiet foreach --recursive 'test x$name = xccan || git archive --prefix "'"$sw"'/$path/" --format tar HEAD'
 	(
 		cd ccan-upstream
@@ -65,7 +65,7 @@ docs='
 	AUTHORS
 	COPYING
 	NEWS
-	README
+	README.md
 	README.ASIC
 	README.FPGA
 	README.GPU
@@ -92,13 +92,6 @@ for build in "${builds[@]}"; do
 		CFLAGS="${CFLAGS} -Wall" \
 		--disable-cpumining \
 		--enable-opencl \
-		--enable-adl \
-		--enable-bitforce \
-		--enable-icarus \
-		--enable-modminer \
-		--enable-ztex \
-		--enable-keccak \
-		--enable-scrypt \
 		--without-system-libbase58 \
 		--host="$machine"
 	make $MAKEOPTS
@@ -112,7 +105,7 @@ for build in "${builds[@]}"; do
 		*.exe \
 		libblkmaker/.libs/*.dll \
 		libbase58/.libs/*.dll \
-		opencl \
+		opencl/rad.cl \
 		example.conf \
 		windows-build.txt \
 		miner.php \
@@ -165,6 +158,8 @@ for build in "${builds[@]}"; do
 			for my $check_libdir (
 				"/usr/$machine/usr/lib",
 				"/usr/$machine/usr/bin",
+				"/usr/$machine/lib",
+				"/usr/$machine/bin",
 			) {
 				$dll = ciexist "$check_libdir/${dlllc}";
 				if ($dll) {
@@ -174,11 +169,12 @@ for build in "${builds[@]}"; do
 			}
 			if (not defined $libdir) {
 				return if $opt;
-				die "Cannot find $dlllc\n"
+				printf("Cannot find $dlllc\n")
+			} else {
+				system("cp -v -L \"$libdir/$dll\" \"$PKGDIR\"") && die "Copy $dll failed\n";
+				system("\"${machine}-strip\" \"$PKGDIR/$dll\"") && die "Strip $dll failed\n";
+				push @todo, $dll;
 			}
-			system("cp -v -L \"$libdir/$dll\" \"$PKGDIR\"") && die "Copy $dll failed\n";
-			system("\"${machine}-strip\" \"$PKGDIR/$dll\"") && die "Strip $dll failed\n";
-			push @todo, $dll;
 			$have{$dlllc} = undef;
 			1
 		}

--- a/miner.c
+++ b/miner.c
@@ -6176,7 +6176,9 @@ static void disable_curses(void)
 		delwin(logwin);
 		delwin(statuswin);
 		delwin(mainwin);
-		//endwin();
+#ifndef WIN32
+		endwin();
+#endif
 #ifdef WIN32
 		// Move the cursor to after curses output.
 		HANDLE hout = GetStdHandle(STD_OUTPUT_HANDLE);

--- a/miner.c
+++ b/miner.c
@@ -243,6 +243,7 @@ bool opt_disable_client_reconnect = false;
 static bool no_work;
 bool opt_worktime;
 bool opt_weighed_stats;
+bool opt_no_sleep = false;
 
 char *opt_kernel_path;
 char *cgminer_path;
@@ -2829,6 +2830,9 @@ static struct opt_table opt_config_table[] = {
 			"Display extra work time debug information"),
 	OPT_WITH_ARG("--pools",
 			opt_set_bool, NULL, NULL, opt_hidden),
+	OPT_WITHOUT_ARG("--no-sleep",
+			opt_set_bool, &opt_no_sleep,
+			"Don't sleep while waiting for OpenCL kernel"),
 	OPT_ENDTABLE
 };
 
@@ -8541,7 +8545,8 @@ static void set_options(void)
 	immedok(logwin, true);
 	loginput_mode(8);
 retry:
-	wlogprint("\n[L]ongpoll: %s\n", want_longpoll ? "On" : "Off");
+	wlogprint("\n[N]o sleep: %s\n", opt_no_sleep ? "On" : "Off");
+	wlogprint("[L]ongpoll: %s\n", want_longpoll ? "On" : "Off");
 	wlogprint("[Q]ueue: %d\n[S]cantime: %d\n[E]xpiry: %d\n[R]etries: %d\n"
 		  "[W]rite config file\n[B]FGMiner restart\n",
 		opt_queue, opt_scantime, opt_expiry, opt_retries);
@@ -8556,6 +8561,10 @@ retry:
 			goto retry;
 		}
 		opt_queue = selected;
+		goto retry;
+	} else if (!strncasecmp(&input, "n", 1)) {
+		opt_no_sleep = !opt_no_sleep;
+		applog(LOG_WARNING, "No sleep %s", opt_no_sleep ? "enabled" : "disabled");
 		goto retry;
 	} else if (!strncasecmp(&input, "l", 1)) {
 		if (want_longpoll)

--- a/miner.h
+++ b/miner.h
@@ -535,6 +535,11 @@ struct cgpu_info {
 	pthread_mutex_t		device_mutex;
 	pthread_cond_t	device_cond;
 
+	uint64_t kernel_wait_times[50];
+	double kernel_wait_us;
+	unsigned int kernel_wait_index;
+	unsigned int kernel_wait_min;
+
 	enum dev_enable deven;
 	bool already_set_defaults;
 	int accepted;

--- a/version.c
+++ b/version.c
@@ -13,4 +13,4 @@
 
 const char * const bfgminer_name_space_ver = PACKAGE " " VERSION;
 const char * const bfgminer_name_slash_ver = PACKAGE "/" VERSION;
-const char * const bfgminer_ver = "rad-bfgminer";
+const char * const bfgminer_ver = VERSION;


### PR DESCRIPTION
This change will reduce CPU usage when using Nvidia GPUs. To prevent Nvidia's busywait, threads will now sleep while waiting for the kernel to finish running. There should be negligible change to hashrate. Sleeping can be disabled with the --no-sleep argument or toggled in the settings interface.

Fixed a bug introduced in the last version where the terminal isn't restored. This change was only meant to apply to Windows.

Version number has been corrected so it will show 1.0.3 instead of 5.5.0.